### PR TITLE
Readme update and manifest element id update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,17 @@
 # react-iiif-media-player
+A ReactJS component which renders both a MediaelementJS player (http://www.mediaelementjs.com/) and structured navigation from a IIIF 3.0 spec manifest.  
 
-[![Travis][build-badge]][build]
-[![npm package][npm-badge]][npm]
-[![Coveralls][coveralls-badge]][coveralls]
+## General Usage:
+Add the `react-iiif-media-player` component into your ReactJS application via `yarn` or `npm`.
 
-Note: This is a work in progress...
+`yarn add react-iiif-media-player`  or,
+`npm install --save react-iiif-media-player`
 
-### Instructions
-Import the root component from `react-iiif-media-player`, and place somewhere in your React application.  The imported component will look for a `div` with the following attributes on which to mount itself to, rendering a MediaelementJS player (http://www.mediaelementjs.com/) and any defined IIIF `structures []` navigation links found in the IIIF manifest.
+The component will look for an element of `id="iiif-manifest-url"` and read the manifest url from a data attribute  `data-manifest-url="http://your-manifest-url-here"`
 
-`<div id="avln-iiif-player-root" data-manifest-url="https://mallorn.dlib.indiana.edu/lunchroom_manners.manifest.json"></div>`
+#### Example manifest element
 
-`data-manifest-url` should be a uri for a public IIIF manifest 3.0 json file.
-
-#### Example IIIF 3.0 spec manifest
-https://mallorn.dlib.indiana.edu/lunchroom_manners.manifest.json
-
-#### IIIF 3.0 spec
-http://iiif.io/api/presentation/3.0/
-
+`<div id="iiif-manifest-url" data-manifest-url="https://mallorn.dlib.indiana.edu/lunchroom_manners.manifest.json"></div>`
 
 ### Example usage:
 ```
@@ -30,7 +23,7 @@ class Demo extends Component {
   render() {
     return (
       <div>
-        <div id="avln-iiif-player-root" data-manifest-url="https://mallorn.dlib.indiana.edu/lunchroom_manners.manifest.json"></div>
+        <div id="iiif-manifest-url" data-manifest-url="https://mallorn.dlib.indiana.edu/lunchroom_manners.manifest.json"></div>
         <IIIFPlayer />
       </div>
     );
@@ -39,6 +32,14 @@ class Demo extends Component {
 
 render(<Demo />, document.querySelector('#demo'));
 ```
+
+`data-manifest-url` should be a uri for a public IIIF manifest 3.0 json file.
+
+#### IIIF 3.0 spec
+http://iiif.io/api/presentation/3.0/
+
+#### Example IIIF 3.0 spec manifest
+https://mallorn.dlib.indiana.edu/lunchroom_manners.manifest.json
 
 ### Configuration
 The vision is to support various configurations on the player itself, and network requests when retrieving a manifest.  For now, the only supported configuration is `credentials` under `fetch`'s `init` configuration object (https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch).  Here's an example configuration:
@@ -76,6 +77,43 @@ render(<Demo />, document.querySelector('#demo'));
 ### IIIF Manifest Testing
 To live test IIIF 3.0 spec manifests, the following Github branch is set up for testing:
 https://avalonmediasystem.github.io/avalon-iiif-player/
+
+## Developing
+
+### Run the application locally
+First clone the repository:
+
+`git clone git@github.com:avalonmediasystem/react-iiif-media-player.git`
+
+Install dependencies:
+
+`yarn install`
+
+Run the demo application:
+
+`yarn start`  or  `npm run start`
+
+View the application in a web browser.  Visit:
+
+http://localhost:3000/
+
+### Development process
+Work on all files located in `/src`, and in development mode you can test your work in the demo application (`/demo/src`).  This is what is displayed at http://localhost:3000/.
+
+## Building the package
+When you're ready to build the package, run:
+
+`yarn run build`  or   `npm run build`
+
+This will create NPM/Yarn package files which can be pushed to the NPM registry.  
+
+
+## Tests
+In process of transitioning all tests to Jest. For now, run:
+
+`yarn test:jest`  or  `npm run test:jest`
+
+
 
 
 [build-badge]: https://img.shields.io/travis/user/repo/master.png?style=flat-square

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -20,7 +20,7 @@ class Demo extends Component {
       <div>
         <h1>react-iiif-media-player Demo</h1>
         <div
-          id="avln-iiif-player-root"
+          id="iiif-manifest-url"
           data-manifest-url="https://mallorn.dlib.indiana.edu/lunchroom_manners.manifest.json"
         />
         <IIIFPlayer config={config} />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-iiif-media-player",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "react-iiif-media-player React component for rendering a media player for a IIIF 3.0 spec manifest",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-iiif-media-player",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "react-iiif-media-player React component for rendering a media player for a IIIF 3.0 spec manifest",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
   "name": "react-iiif-media-player",
-  "version": "1.0.8",
-  "description":
-    "react-iiif-media-player React component for rendering a media player for a IIIF 3.0 spec manifest",
+  "version": "1.1.0",
+  "description": "react-iiif-media-player React component for rendering a media player for a IIIF 3.0 spec manifest",
   "main": "lib/index.js",
   "module": "es/index.js",
-  "files": ["css", "es", "lib", "umd"],
+  "files": [
+    "css",
+    "es",
+    "lib",
+    "umd"
+  ],
   "scripts": {
     "build": "nwb build-react-component",
     "clean": "nwb clean-module && nwb clean-demo",
@@ -40,10 +44,14 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url":
-      "git+https://github.com/avalonmediasystem/react-iiif-media-player.git"
+    "url": "git+https://github.com/avalonmediasystem/react-iiif-media-player.git"
   },
-  "keywords": ["IIIF", "media", "player", "react-component"],
+  "keywords": [
+    "IIIF",
+    "media",
+    "player",
+    "react-component"
+  ],
   "jest": {
     "moduleNameMapper": {
       "\\.(css|jpg|png)$": "<rootDir>/empty-module.js"

--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,7 @@ class App extends Component {
   }
 
   getManifestUrl() {
-    const el = document.getElementById('avln-iiif-player-root');
+    const el = document.getElementById('iiif-manifest-url');
     if (!el) {
       return '';
     }


### PR DESCRIPTION
@cjcolvar Note this update to the element `id` name will need an update in `avalon-bundle`...I'll work on that next.   I just made the id more generic `iiif-manifest-url`, instead of relying up "avalon" or "avln", etc.