### PR TITLE
Fix hls error when using the player in another application

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.3.1",
     "@fortawesome/react-fontawesome": "^0.1.2",
     "axios": "^0.18.0",
-    "hls.js": "^0.12.4",
+    "hls.js": "0.12.3-canary.4258",
     "manifesto.js": "^3.0.11",
     "mediaelement": "^4.2.10",
     "prop-types": "^15.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3199,10 +3199,10 @@ he@1.2.x:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hls.js@^0.12.4:
-  version "0.12.4"
-  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-0.12.4.tgz#c155b7b2825a11117c111b781973c0ffa759006b"
-  integrity sha512-e8OPxQ60dBVsdkv4atdxR21KzC1mgwspM41qpozpj3Uv1Fz4CaeQy3FWoaV2O+QKKbNRvV5hW+/LipCWdrwnMQ==
+hls.js@0.12.3-canary.4258:
+  version "0.12.3-canary.4258"
+  resolved "https://registry.yarnpkg.com/hls.js/-/hls.js-0.12.3-canary.4258.tgz#9ef7e89a85609222497512b9baed806712246901"
+  integrity sha512-uSNt4fDVNb5rMpgMGjFvVaIqWwwRnIFiCrTY2zHCIQbaKgw8DOhA3QC5ImYdv8nXiZod5LS69dYxjnj/u8+3nw==
   dependencies:
     eventemitter3 "3.1.0"
     url-toolkit "^2.1.6"


### PR DESCRIPTION
So I'm guessing what happened was, the line
```
window.Hls = hlsjs;
```
in react-iiif-media-player code says to the hosting application to look for native Hls support from the browser, which both Chrome and Firefox does not  have according this website: https://caniuse.com/#search=hls. But the existing code worked in Safari because it has Hls support.

Therefore removing that line made the Hls error goes away. Because that was only place `hls.js` is being used I removed `hls.js` entirely from `react-iiif-media-player`.

But I still don't have an explanation for why it worked in the standalone mode :|