### PR TITLE
Use new version of node orb to simplify circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,38 +1,19 @@
 orbs:
-  node: circleci/node@2.0
+  node: circleci/node@3.0
 version: 2.1
-jobs:
-  test:
-    environment:
-      JEST_JUNIT_OUTPUT_DIR: "test-results/jest"
-    executor:
-      name: node/default
-      tag: << parameters.version >>
-    parameters:
-      version:
-        default: 13.12.0
-        description: >
-          A full version tag must be specified. Example: "13.11.0" For a full list
-          of releases, see the following: https://nodejs.org/en/download/releases
-        type: string
-    steps:
-      - checkout
-      - node/install-packages:
-          pkg-manager: yarn
-          cache-key: yarn.lock
-      - run:
-          command: yarn test
-      - store_test_results:
-          path: test-results
+
 workflows:
   test-matrix:
     jobs:
-      - test:
+      - node/test:
           name: node-13
           version: 13.12.0
-      - test:
+          pkg-manager: yarn
+      - node/test:
           name: node-12
           version: 12.16.1
-      - test:
+          pkg-manager: yarn
+      - node/test:
           name: node-10
           version: 10.19.0
+          pkg-manager: yarn


### PR DESCRIPTION
The previous version of the node orb didn't allow using yarn.lock with caching enabled (https://github.com/CircleCI-Public/node-orb/issues/25).  This was fixed in v3 of the orb (https://github.com/CircleCI-Public/node-orb/pull/38) so we can revert to using the stock job which makes for a real nice config file.  The only thing we lose by doing this is the storing of test results since `store_test_results` isn't run by `node/test`.